### PR TITLE
Minor tweaks to home page and news layout

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -8,8 +8,7 @@ copyright = ""
 defaultContentLanguage = "en"
 # Set to true to keep url path preserve casing (eg, for sections)
 disablePathToLower = false
-# Site-level description
-description = "Website and documentation for the Hugo Project, the world's fastest framework for building websites."
+
 # Allows use of emoji shorthand directly in content
 enableEmoji = true
 # Set the unicode character used for the "return" link in page footnotes.
@@ -49,6 +48,7 @@ twitter = "GoHugoIO"
 
 #CUSTOM PARAMS
 [params]
+  description = "The world’s fastest framework for building websites"
   ## Used for views in rendered HTML (i.e., rather than using the .Hugo variable)
   release = "0.20"
   ## Setting this to true will add a "noindex" to *EVERY* page on the site


### PR DESCRIPTION
The description parameter wasn't under the "params" section so the header on the home page wasn't rendering at all. I also updated the copy to what it was on the prototype.

And I fixed what I think was the issue news page rendering as a docs page (the default). It wasn't breaking on my local copy, so I'm not 100% sure that's the issue, but it seems like a likely candidate. 