### PR TITLE
Add release notes for v0.20 - 0.25.1

### DIFF
--- a/content/news/0-20-1.md
+++ b/content/news/0-20-1.md
@@ -1,0 +1,14 @@
+---
+date: 2017-04-13T13:53:58-04:00
+categories: ["Releases"]
+description: "Hugo 0.20.1 is a bug fix release, fixing some important regressions introduced in 0.20"
+link: ""
+title: "April Release"
+draft: false
+author: bep
+---
+
+*   Fix logic for base template in work dir vs in the theme [#3323](//github.com/spf13/hugo/issues/3323)
+*   camelCased templates (partials, shortcodes etc.) not found [#3333](//github.com/spf13/hugo/issues/3333)
+*   Live-reload fails with `_index.md` with paginator [#3315](//github.com/spf13/hugo/issues/3315)
+*   `rssURI` WARNING always shown [#3319](//github.com/spf13/hugo/issues/3319)

--- a/content/news/0-20-2.md
+++ b/content/news/0-20-2.md
@@ -1,0 +1,44 @@
+---
+date: 2017-04-16T13:53:58-04:00
+categories: ["Releases"]
+description: "Hugo 0.20.2 adds support for plain text partials included into HTML templates"
+link: ""
+title: "April Release"
+draft: false
+author: bep
+---
+
+Hugo `0.20.2` adds support for plain text partials included into `HTML` templates. This was a side-effect of the big new [Custom Output Format](https://gohugo.io/extras/output-formats/) feature in `0.20`, and while the change was intentional and there was an ongoing discussion about fixing it in [#3273](//github.com/spf13/hugo/issues/3273), it did break some themes. There were valid workarounds for these themes, but we might as well get it right.
+
+The most obvious use case for this is inline `CSS` styles, which you now can do without having to name your partials with a `html` suffix.
+
+A simple example:
+
+In `layouts/partials/mystyles.css`:
+
+    body {
+    	background-color: {{ .Param "colors.main" }}
+    }
+
+Then in `config.toml` (note that by using the `.Param` lookup func, we can override the color in a page’s front matter if we want):
+
+    [params]
+    [params.colors]
+    main = "green"
+    text = "blue"
+
+And then in `layouts/partials/head.html` (or the partial used to include the head section into your layout):
+
+    <head>
+        <style type="text/css">
+        {{ partial "mystyles.css" . | safeCSS }}
+        </style>
+    </head>
+
+Of course, `0.20` also made it super-easy to create external `CSS` stylesheets based on your site and page configuration. A simple example:
+
+Add “CSS” to your home page’s `outputs` list, create the template `/layouts/index.css` using Go template syntax for the dynamic parts, and then include it into your `HTML` template with:
+
+    {{ with  .OutputFormats.Get "css" }}
+    <link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink |  safeURL }}">
+    {{ end }}`

--- a/content/news/0-20-3.md
+++ b/content/news/0-20-3.md
@@ -1,0 +1,25 @@
+---
+date: 2017-04-24T13:53:58-04:00
+categories: ["Releases"]
+description: "This is a bug-fix release with one important fix. But it also adds some harness around GoReleaser"
+link: ""
+title: "April Release"
+draft: false
+author: bep
+---
+
+This is a bug-fix release with one important fix. But it also adds some harness around [GoReleaser](https://github.com/goreleaser/goreleaser) to automate the Hugo release process. Big thanks to [@caarlos0](https://github.com/caarlos0) for great and super-fast support fixing issues along the way.
+
+Hugo now has:
+
+* 16619&#43; [stars](https://github.com/spf13/hugo/stargazers)
+* 458&#43; [contributors](https://github.com/spf13/hugo/graphs/contributors)
+* 156&#43; [themes](http://themes.gohugo.io/)
+
+## Enhancement
+
+* Automate the Hugo release process [550eba64](https://github.com/spf13/hugo/commit/550eba64705725eb54fdb1042e0fb4dbf6f29fd0) [@bep](https://github.com/bep) [#3358](https://github.com/spf13/hugo/issues/3358) 
+
+## Fix
+
+* Fix handling of zero-length files [9bf5c381](https://github.com/spf13/hugo/commit/9bf5c381b6b3e69d4d8dbfd7a40074ac44792bbf) [@bep](https://github.com/bep) [#3355](https://github.com/spf13/hugo/issues/3355) 

--- a/content/news/0-20-4.md
+++ b/content/news/0-20-4.md
@@ -1,0 +1,23 @@
+---
+date: 2017-04-24T17:53:58-04:00
+categories: ["Releases"]
+description: "This is the second bug-fix release of the day, fixing a couple of issues related to the new release scripts"
+link: ""
+title: "April Release"
+draft: false
+author: bep
+---
+
+This is the second bug-fix release of the day, fixing a couple of issues related to the new release scripts.
+
+Hugo now has:
+
+* 16626&#43; [stars](https://github.com/spf13/hugo/stargazers)
+* 457&#43; [contributors](https://github.com/spf13/hugo/graphs/contributors)
+* 156&#43; [themes](http://themes.gohugo.io/)
+
+## Fixes
+
+* Fix statically linked binaries [275bcf56](https://github.com/spf13/hugo/commit/275bcf566c7cb72367d4423cf4810319311ff680) [@munnerz](https://github.com/munnerz) [#3382](https://github.com/spf13/hugo/issues/3382) 
+* Filename change in Hugo 0.20.3 binaries [#3385](https://github.com/spf13/hugo/issues/3385)
+* Fix version calculation [cb3c6b6f](https://github.com/spf13/hugo/commit/cb3c6b6f7670f85189a4a3637e7132901d1ed6e9) [@bep](https://github.com/bep) 

--- a/content/news/0-20-5.md
+++ b/content/news/0-20-5.md
@@ -1,0 +1,11 @@
+---
+date: 2017-04-25T17:53:58-04:00
+categories: ["Releases"]
+description: ""
+link: ""
+title: "April Release"
+draft: false
+author: bep
+---
+
+This is a bug-fix release which fixes the version number of `0.20.4` (which wrongly shows up as `0.21-DEV`) ([#3388](https://github.com/spf13/hugo/issues/3388)).

--- a/content/news/0-20-6.md
+++ b/content/news/0-20-6.md
@@ -1,0 +1,23 @@
+---
+date: 2017-04-27T17:53:58-04:00
+categories: ["Releases"]
+description: ""
+link: ""
+title: "April Release"
+draft: false
+author: bep
+---
+
+There have been some [shouting on discuss.gohugo.io](https://discuss.gohugo.io/t/index-md-is-generated-in-subfolder-index-index-html-hugo-0-20/6338/15) about some broken sites after the release of Hugo `0.20`. This release reintroduces the old behaviour, making  `/my-blog-post/index.md` work as expected.
+
+Hugo now has:
+
+* 16675&#43; [stars](https://github.com/spf13/hugo/stargazers)
+* 456&#43; [contributors](https://github.com/spf13/hugo/graphs/contributors)
+* 156&#43; [themes](http://themes.gohugo.io/)
+
+## Fixes
+
+* Avoid index.md in /index/index.html [#3396](https://github.com/spf13/hugo/issues/3396) 
+* Make missing GitInfo a WARNING [b30ca4be](https://github.com/spf13/hugo/commit/b30ca4bec811dbc17e9fd05925544db2b75e0e49) [@bep](https://github.com/bep) [#3376](https://github.com/spf13/hugo/issues/3376) 
+* Fix some of the fpm fields for deb [3bd1d057](https://github.com/spf13/hugo/commit/3bd1d0571d5f2f6bf0dc8f90a8adf2dbfcb2fdfd) [@anthonyfok](https://github.com/anthonyfok) 

--- a/content/news/0-20-7.md
+++ b/content/news/0-20-7.md
@@ -1,0 +1,22 @@
+---
+date: 2017-05-03T17:53:58-04:00
+categories: ["Releases"]
+description: "This just fixes an issue with the release scripts, no change in the binaries"
+link: ""
+title: "May Release"
+draft: false
+author: bep
+---
+
+This just fixes an issue with the release scripts, no change in the binaries.
+
+
+Hugo now has:
+
+* 16782&#43; [stars](https://github.com/spf13/hugo/stargazers)
+* 458&#43; [contributors](https://github.com/spf13/hugo/graphs/contributors)
+* 156&#43; [themes](http://themes.gohugo.io/)
+
+## Fix
+
+* Push the tag before goreleaser is run [3682bf52](https://github.com/spf13/hugo/commit/3682bf527989e86d9da32d76809306cb576383e8) [@bep](https://github.com/bep) [#3405](https://github.com/spf13/hugo/issues/3405) 

--- a/content/news/0-20.md
+++ b/content/news/0-20.md
@@ -1,0 +1,71 @@
+---
+date: 2017-04-10T13:53:58-04:00
+categories: ["Releases"]
+description: "Hugo 0.20 introduces the powerful and long sought after feature Custom Output Formats"
+link: ""
+title: "April Release"
+draft: false
+author: bep
+---
+
+Hugo `0.20` introduces the powerful and long sought after feature [Custom Output Formats](http://gohugo.io/extras/output-formats/); Hugo isn’t just that “static HTML with an added RSS feed” anymore. _Say hello_ to calendars, e-book formats, Google AMP, and JSON search indexes, to name a few ( [#2828](//github.com/spf13/hugo/issues/2828) ).
+
+This release represents **over 180 contributions by over 30 contributors** to the main Hugo code base. Since last release Hugo has **gained 1100 stars, 20 new contributors and 5 additional themes.**
+
+Hugo now has:
+
+*   16300+ stars
+*   495+ contributors
+*   156+ themes
+
+[@bep](//github.com/bep) still leads the Hugo development with his witty Norwegian humor, and once again contributed a significant amount of additions. Also a big shoutout to [@digitalcraftsman](//github.com/digitalcraftsman) for his relentless work on keeping the documentation and the themes site in pristine condition, and [@moorereason](//github.com/moorereason) and [@bogem](//github.com/bogem) for their ongoing contributions.
+
+## Other Highlights
+
+[@bogem](//github.com/bogem) has also contributed TOML as an alternative and much simpler format for language/i18n files ([#3200](//github.com/spf13/hugo/issues/3200)). A feature you will appreciate when you start to work on larger translations.
+
+Also, there have been some important updates in the Emacs Org-mode handling: [@chaseadamsio](//github.com/chaseadamsio) has fixed the newline-handling ( [#3126](//github.com/spf13/hugo/issues/3126) ) and [@clockoon](//github.com/clockoon) has added basic footnote support.
+
+Worth mentioning is also the ongoing work that [@rdwatters](//github.com/rdwatters) and [@budparr](//github.com/budparr) is doing to re-do the [gohugo.io](https://gohugo.io/) site, including a total restructuring and partial rewrite of the documentation. It is getting close to finished, and it looks fantastic!
+
+## Notes
+
+*   `RSS` description in the built-in template is changed from full `.Content` to `.Summary`. This is a somewhat breaking change, but is what most people expect from their RSS feeds. If you want full content, please provide your own RSS template.
+*   The deprecated `.RSSlink` is now removed. Use `.RSSLink`.
+*   `RSSUri` is deprecated and will be removed in a future Hugo version, replace it with an output format definition.
+*   The deprecated `.Site.GetParam` is now removed, use `.Site.Param`.
+*   Hugo does no longer append missing trailing slash to `baseURL` set as a command line parameter, making it consistent with how it behaves from site config. [#3262](//github.com/spf13/hugo/issues/3262)
+
+## Enhancements
+
+*   Hugo `0.20` is built with Go 1.8.1.
+*   Add `.Site.Params.mainSections` that defaults to the section with the most pages. Plan is to get themes to use this instead of the hardcoded `blog` in `where` clauses. [#3206](//github.com/spf13/hugo/issues/3206)
+*   File extension is now configurable. [#320](//github.com/spf13/hugo/issues/320)
+*   Impove `markdownify` template function performance. [#3292](//github.com/spf13/hugo/issues/3292)
+*   Add taxonomy terms’ pages to `.Data.Pages` [#2826](//github.com/spf13/hugo/issues/2826)
+*   Change `RSS` description from full `.Content` to `.Summary`.
+*   Ignore “.” dirs in `hugo --cleanDestinationDir` [#3202](//github.com/spf13/hugo/issues/3202)
+*   Allow `jekyll import` to accept both `2006-01-02` and `2006-1-2` date format [#2738](//github.com/spf13/hugo/issues/2738)
+*   Raise the default `rssLimit` [#3145](//github.com/spf13/hugo/issues/3145)
+*   Unify section list vs single template lookup order [#3116](//github.com/spf13/hugo/issues/3116)
+*   Allow `apply` to be used with the built-in Go template funcs `print`, `printf` and `println`. [#3139](//github.com/spf13/hugo/issues/3139)
+
+## Fixes
+
+*   Fix deadlock in `getJSON` [#3211](//github.com/spf13/hugo/issues/3211)
+*   Make sure empty terms pages are created. [#2977](//github.com/spf13/hugo/issues/2977)
+*   Fix base template lookup order for sections [#2995](//github.com/spf13/hugo/issues/2995)
+*   `URL` fixes:
+    *   Fix pagination URLs with `baseURL` with sub-root and `canonifyUrls=false` [#1252](//github.com/spf13/hugo/issues/1252)
+    *   Fix pagination URL for resources with “.” in name [#2110](//github.com/spf13/hugo/issues/2110) [#2374](//github.com/spf13/hugo/issues/2374) [#1885](//github.com/spf13/hugo/issues/1885)
+    *   Handle taxonomy names with period [#3169](//github.com/spf13/hugo/issues/3169)
+    *   Handle `uglyURLs` ambiguity in `Permalink` [#3102](//github.com/spf13/hugo/issues/3102)
+    *   Fix `Permalink` for language-roots wrong when `uglyURLs` is `true` [#3179](//github.com/spf13/hugo/issues/3179)
+    *   Fix misc case issues for `URLs` [#1641](//github.com/spf13/hugo/issues/1641)
+    *   Fix for taxonomies URLs when `uglyUrls=true` [#1989](//github.com/spf13/hugo/issues/1989)
+    *   Fix empty `RSSLink` for list pages with content page. [#3131](//github.com/spf13/hugo/issues/3131)
+*   Correctly identify regular pages on the form “my_index_page.md” [#3234](//github.com/spf13/hugo/issues/3234)
+*   `Exit -1` on `ERROR` in global logger [#3239](//github.com/spf13/hugo/issues/3239)
+*   Document hugo `help command` [#2349](//github.com/spf13/hugo/issues/2349)
+*   Fix internal `Hugo` version handling for bug fix releases. [#3025](//github.com/spf13/hugo/issues/3025)
+*   Only return `RSSLink` for pages that actually have a RSS feed. [#1302](//github.com/spf13/hugo/issues/1302)

--- a/content/news/0-21.md
+++ b/content/news/0-21.md
@@ -1,0 +1,104 @@
+---
+date: 2017-05-22T17:53:58-04:00
+categories: ["Releases"]
+description: "Hugo 0.21 brings full support for shortcodes per Output Format, the last vital piece of that puzzle"
+link: ""
+title: "May Release"
+draft: false
+author: bep
+---
+
+Hugo `0.21` brings full support for shortcodes per [Output Format](https://gohugo.io/extras/output-formats/) ([#3220](https://github.com/spf13/hugo/issues/3220)), the last vital piece of that puzzle. This is especially useful for `Google AMP` with its many custom media tags.
+
+This release represents **126 contributions by 29 contributors** to the main Hugo code base. Since last main release Hugo has **gained 850 stars and 7 additional themes**.
+
+Hugo now has:
+
+* 17156&#43; [stars](https://github.com/spf13/hugo/stargazers)
+* 457&#43; [contributors](https://github.com/spf13/hugo/graphs/contributors)
+* 163&#43; [themes](http://themes.gohugo.io/)
+
+[@bep](https://github.com/bep) leads the Hugo development with a significant amount of contributions, but also a big shoutout to [@moorereason](https://github.com/moorereason), [@bogem](https://github.com/bogem), and [@munnerz](https://github.com/munnerz) for their ongoing contributions. And as always a big thanks to [@digitalcraftsman](https://github.com/digitalcraftsman) for his relentless work on keeping the documentation and the themes site in pristine condition.
+
+## Other Highlights
+
+On a more technical side, [@moorereason](https://github.com/moorereason) and [@bep](https://github.com/bep) have introduced namespaces for Hugo&#39;s many template funcs ([#3042](https://github.com/spf13/hugo/issues/3042) ). There are so many now, and adding more into that big pile would be a sure path toward losing control.  Now they are nicely categorised into namespaces with its own tests and examples, with an API that the documentation site can use to make sure it is correct and up-to-date.
+
+## Notes
+
+* The deprecated `.Extension`, `.Now` and `.TargetPath` will now `ERROR` [544f0a63](https://github.com/spf13/hugo/commit/544f0a6394b0e085d355e8217fc5bb3d96c12a98) [@bep](https://github.com/bep) 
+* The config settings and flags `disable404`, `disableRSS`, `disableSitemap`, `disableRobotsTXT` are now deprecated. Use `disableKinds`. [5794a265](https://github.com/spf13/hugo/commit/5794a265b41ffdeebfd8485eecf65cf4088d49d6) [@bep](https://github.com/bep) [#3345](https://github.com/spf13/hugo/issues/3345) 
+
+## Enhancements
+
+### Templates
+
+* Log a WARNING on wrong usage of `IsSet` [38661c17](https://github.com/spf13/hugo/commit/38661c17bb8c31c9f31ee18f8eba5e3bfddd5574) [@moorereason](https://github.com/moorereason) [#3092](https://github.com/spf13/hugo/issues/3092) 
+* Add support for ellipsed paginator navigator, making paginators with lots of pages more compact  [b6ea492b](https://github.com/spf13/hugo/commit/b6ea492b7a6325d04d44eeb00a990a3a0e29e0c0) [@bep](https://github.com/bep) [#3466](https://github.com/spf13/hugo/issues/3466) 
+* Add support for interfaces to `intersect` [f1c29b01](https://github.com/spf13/hugo/commit/f1c29b017bbd88e701cd5151dd186e868672ef89) [@moorereason](https://github.com/moorereason) [#1952](https://github.com/spf13/hugo/issues/1952) 
+* Add `NumFmt` function [93b3b138](https://github.com/spf13/hugo/commit/93b3b1386714999d716e03b131f77234248f1724) [@moorereason](https://github.com/moorereason) [#1444](https://github.com/spf13/hugo/issues/1444) 
+* Add template function namespaces [#3418](https://github.com/spf13/hugo/issues/3418)  [#3042](https://github.com/spf13/hugo/issues/3042)  [@moorereason](https://github.com/moorereason)  [@bep](https://github.com/bep) 
+* Add translation links to the default sitemap template [90d3fbf1](https://github.com/spf13/hugo/commit/90d3fbf1da93a279cfe994a226ae82cf5441deab) [@rayjolt](https://github.com/rayjolt) [#2569](https://github.com/spf13/hugo/issues/2569) 
+* Allow text partials in HTML templates and the other way around [1cf29200](https://github.com/spf13/hugo/commit/1cf29200b4bb0a9c006155ec76759b7f4b1ad925) [@bep](https://github.com/bep) [#3273](https://github.com/spf13/hugo/issues/3273) 
+
+### Output
+
+* Refactor site rendering with an &#34;output format context&#34;. In this release, this is used for shortcode handling only, but this paves the way for future niceness [1e4d082c](https://github.com/spf13/hugo/commit/1e4d082cf5b92fedbc60b1b4f0e9d1ee6ec45e33) [@bep](https://github.com/bep) [#3397](https://github.com/spf13/hugo/issues/3397)  [2bcbf104](https://github.com/spf13/hugo/commit/2bcbf104006e0ec03be4fd500f2519301d460f8c) [@bep](https://github.com/bep) [#3220](https://github.com/spf13/hugo/issues/3220) 
+
+
+### Core
+
+* Handle `shortcode` per `Output Format` [af72db80](https://github.com/spf13/hugo/commit/af72db806f2c1c0bf1dfe5832275c41eeba89906) [@bep](https://github.com/bep) [#3220](https://github.com/spf13/hugo/issues/3220) 
+* Improve shortcode error message [58d9cbd3](https://github.com/spf13/hugo/commit/58d9cbd31bcf7c296a39860fd7e566d10faaff28) [@bep](https://github.com/bep) 
+* Avoid `index.md` in `/index/index.html` [fea4fd86](https://github.com/spf13/hugo/commit/fea4fd86a324bf9679df23f8289887d91b42e919) [@bep](https://github.com/bep) [#3396](https://github.com/spf13/hugo/issues/3396) 
+* Make missing `GitInfo` a `WARNING` [5ad2f176](https://github.com/spf13/hugo/commit/5ad2f17693a9860be76ef8089c8728d2b59d6b04) [@bep](https://github.com/bep) [#3376](https://github.com/spf13/hugo/issues/3376) 
+* Prevent decoding `pageParam` in common cases [e98f885b](https://github.com/spf13/hugo/commit/e98f885b8af27f5473a89d31d0b1f02e61e8a5ec) [@bogem](https://github.com/bogem) 
+* Ignore non-source files on partial rebuild [b5b6e81c](https://github.com/spf13/hugo/commit/b5b6e81c0269abf9b0f4bc6a127744a25344e5c6) [@xofyarg](https://github.com/xofyarg) [#3325](https://github.com/spf13/hugo/issues/3325) 
+* Log `WARNING` only on unknown `/data` files [ab692e73](https://github.com/spf13/hugo/commit/ab692e73dea3ddfe979c88ee236cc394e47e82f1) [@bep](https://github.com/bep) [#3361](https://github.com/spf13/hugo/issues/3361) 
+* Avoid processing the same notify event twice [3b677594](https://github.com/spf13/hugo/commit/3b67759495c9268c30e6ba2d8c7e3b75d52d2960) [@bep](https://github.com/bep) 
+* Only show `rssURI` deprecation `WARNING` if it is actually set [cfd3af8e](https://github.com/spf13/hugo/commit/cfd3af8e691119461effa4385251b9d3818e2291) [@bep](https://github.com/bep) [#3319](https://github.com/spf13/hugo/issues/3319) 
+
+### Docs
+
+* Add documentation on slug translation [635b3bb4](https://github.com/spf13/hugo/commit/635b3bb4eb873978c7d52e6c0cb85da0c4d25299) [@xavib](https://github.com/xavib) 
+* Replace `cdn.mathjax.org` with `cdnjs.cloudflare.com` [4b637ac0](https://github.com/spf13/hugo/commit/4b637ac041d17b22187f5ccd0f65461f0065aaa9) [@takuti](https://github.com/takuti) 
+* Add notes about some output format behaviour [162d3a58](https://github.com/spf13/hugo/commit/162d3a586d36cabf6376a76b096fd8b6414487ae) [@jpatters](https://github.com/jpatters) 
+* Add `txtpen` as alternative commenting service [7cdc244a](https://github.com/spf13/hugo/commit/7cdc244a72de4c08edc0008e37aec83d945dccdf) [@rickyhan](https://github.com/rickyhan) 
+
+### Other
+
+* Embed `Page` in `WeightedPage` [ebf677a5](https://github.com/spf13/hugo/commit/ebf677a58360126d8b9a1e98d086aa4279f53181) [@bep](https://github.com/bep) [#3435](https://github.com/spf13/hugo/issues/3435) 
+* Improve the detection of untranslated strings [a40d1f6e](https://github.com/spf13/hugo/commit/a40d1f6ed2aedddc99725658993258cd557640ed) [@bogem](https://github.com/bogem) [#2607](https://github.com/spf13/hugo/issues/2607) 
+* Make first letter of the Hugo commands flags&#39; usage lowercase [f0f69d03](https://github.com/spf13/hugo/commit/f0f69d03c551acb8ac2eeedaad579cf0b596f9ef) [@bogem](https://github.com/bogem) 
+* Import `Octopress` image tag in `Jekyll importer` [5f3ad1c3](https://github.com/spf13/hugo/commit/5f3ad1c31985450fab8d6772e9cbfcb57cf5cc53) [@buynov](https://github.com/buynov) 
+
+## Fixes
+
+### Templates
+
+*  Do not lower case template names [6d2ea0f7](https://github.com/spf13/hugo/commit/6d2ea0f7d7e8a54b8edfc36e52ff74266c30dc27) [@bep](https://github.com/bep) [#3333](https://github.com/spf13/hugo/issues/3333) 
+
+### Output
+
+* Fix output format mixup in example [10287263](https://github.com/spf13/hugo/commit/10287263f529181d3169668b044cb84e2e3b049a) [@bep](https://github.com/bep) [#3481](https://github.com/spf13/hugo/issues/3481) 
+* Fix base theme vs project base template logic [077005e5](https://github.com/spf13/hugo/commit/077005e514b1ed50d84ceb90c7c72f184cb04521) [@bep](https://github.com/bep) [#3323](https://github.com/spf13/hugo/issues/3323) 
+
+### Core
+* Render `404` in default language only [154e18dd](https://github.com/spf13/hugo/commit/154e18ddb9ad205055d5bd4827c87f3f0daf499f) [@mitchchn](https://github.com/mitchchn) [#3075](https://github.com/spf13/hugo/issues/3075) 
+* Fix `RSSLink` vs `RSS` `Output Format` [e682fcc6](https://github.com/spf13/hugo/commit/e682fcc62233b47cf5bdcaf598ac0657ef089471) [@bep](https://github.com/bep) [#3450](https://github.com/spf13/hugo/issues/3450) 
+* Add default config for `ignoreFiles`, making that option work when running in server mode [42f4ce15](https://github.com/spf13/hugo/commit/42f4ce15a9d68053da36f9efcf7a7d975cc59559) [@chaseadamsio](https://github.com/chaseadamsio) 
+* Fix output formats override when no outputs definition given [6e2f2dd8](https://github.com/spf13/hugo/commit/6e2f2dd8d3ca61c92a2ee8824fbf05cadef08425) [@bep](https://github.com/bep) [#3447](https://github.com/spf13/hugo/issues/3447) 
+* Fix handling of zero-length files [0e87b18b](https://github.com/spf13/hugo/commit/0e87b18b66d2c8ba9e2abc429630cb03f5b093d6) [@bep](https://github.com/bep) [#3355](https://github.com/spf13/hugo/issues/3355) 
+* Must recreate `Paginator` on live-reload [45c74526](https://github.com/spf13/hugo/commit/45c74526686f6a2afa02bcee767d837d6b9dd028) [@bep](https://github.com/bep) [#3315](https://github.com/spf13/hugo/issues/3315) 
+
+### Docs
+
+* Fix incorrect path in `templates/list` [27e88154](https://github.com/spf13/hugo/commit/27e88154af2dd9af6d0523d6e67b612e6336f91c) [@MunifTanjim](https://github.com/MunifTanjim) 
+* Fixed incorrect specification of directory structure [a28fbca6](https://github.com/spf13/hugo/commit/a28fbca6dcfa80b6541f5ef6c8c12cd1804ae9ed) [@TejasQ](https://github.com/TejasQ) 
+* Fix `bash` command in `tutorials/github-pages-blog` [c9976155](https://github.com/spf13/hugo/commit/c99761555c014e4d041438d5d7e53a6cbaee4492) [@hansott](https://github.com/hansott) 
+* Fix `.Data.Pages` range in example [b5e32eb6](https://github.com/spf13/hugo/commit/b5e32eb60993b4656918af2c959ae217a68c461e) [@hxlnt](https://github.com/hxlnt) 
+
+### Other
+
+* Fix data race in live-reload close, avoiding some rare panics [355736ec](https://github.com/spf13/hugo/commit/355736ec357c81dfb2eb6851ee019d407090c5ec) [@bep](https://github.com/bep) [#2625](https://github.com/spf13/hugo/issues/2625) 
+* Skip `.git` directories in file scan [94b5be67](https://github.com/spf13/hugo/commit/94b5be67fc73b87d114d94a7bb1a33ab997f30f1) [@bogem](https://github.com/bogem) [#3468](https://github.com/spf13/hugo/issues/3468) 

--- a/content/news/0-22-1.md
+++ b/content/news/0-22-1.md
@@ -1,0 +1,36 @@
+---
+date: 2017-06-13T17:53:58-04:00
+categories: ["Releases"]
+description: "Hugo 0.22.1 fixes a couple of issues reported after the 0.22 release"
+link: ""
+title: "June Release"
+draft: false
+author: bep
+---
+
+Hugo `0.22.1` fixes a couple of issues reported after the [0.22 release](https://github.com/spf13/hugo/releases/tag/v0.22) Monday. Most importantly a fix for detecting regular subfolders below the root-sections.
+
+Also, we forgot to adapt the `permalink settings` with support for nested sections, which made that feature less useful than it could be.
+
+With this release you can configure **permalinks with sections** like this:
+
+**First level only:**
+
+```toml
+[permalinks]
+blog = ":section/:title"
+```
+
+**Nested (all levels):**
+
+```toml
+[permalinks]
+blog = ":sections/:title"
+```
+## Fixes
+
+* Fix section logic for root folders with subfolders [a30023f5](https://github.com/spf13/hugo/commit/a30023f5cbafd06034807255181a5b7b17f3c25f) [@bep](https://github.com/bep) [#3586](https://github.com/spf13/hugo/issues/3586) 
+* Support sub-sections in permalink settings [1f26420d](https://github.com/spf13/hugo/commit/1f26420d392a5ab4c7b7fe1911c0268b45d01ab8) [@bep](https://github.com/bep) [#3580](https://github.com/spf13/hugo/issues/3580) 
+* Adjust rlimit to 64000 [ff54b6bd](https://github.com/spf13/hugo/commit/ff54b6bddcefab45339d8dc2b13776b92bdc04b9) [@bep](https://github.com/bep) [#3582](https://github.com/spf13/hugo/issues/3582) 
+* Make error on setting rlimit a warning only [629e1439](https://github.com/spf13/hugo/commit/629e1439e819a7118ae483381d4634f16d3474dd) [@bep](https://github.com/bep) [#3582](https://github.com/spf13/hugo/issues/3582) 
+* Revert: Remove the rlimit tweaking on macOS [26aa06a3](https://github.com/spf13/hugo/commit/26aa06a3db57ab7134a900d641fa2976f7971520) [@bep](https://github.com/bep) [#3582](https://github.com/spf13/hugo/issues/3582)

--- a/content/news/0-22.md
+++ b/content/news/0-22.md
@@ -1,0 +1,88 @@
+---
+date: 2017-06-12T17:53:58-04:00
+categories: ["Releases"]
+description: "Hugo 0.22 brings nested sections, by popular demand and a long sought after feature"
+link: ""
+title: "June Release"
+draft: false
+author: bep
+---
+
+
+Hugo `0.22` brings **nested sections**, by popular demand and a long sought after feature ([#465](https://github.com/spf13/hugo/issues/465)).  We are still low on documentation for this great feature, but [@bep](https://github.com/bep)  has been kind enough to accompany his implementation with a [demo site](http://hugotest.bep.is/).
+
+This release represents **58 contributions by 10 contributors** to the main Hugo code base. Since last release Hugo has **gained 420 stars and 2 additional themes.**
+
+[@bep](https://github.com/bep) still leads the Hugo development with his witty Norwegian humor, and once again contributed a significant amount of additions. But also a big shoutout to [@bogem](https://github.com/bogem), [@moorereason](https://github.com/moorereason), and [@onedrawingperday](https://github.com/onedrawingperday) for their ongoing contributions. And as always big thanks to [@digitalcraftsman](https://github.com/digitalcraftsman) for his relentless work on keeping the documentation and the themes site in pristine condition.
+
+Hugo now has:
+
+* 17576&#43; [stars](https://github.com/spf13/hugo/stargazers)
+* 455&#43; [contributors](https://github.com/spf13/hugo/graphs/contributors)
+* 165&#43; [themes](http://themes.gohugo.io/)
+
+## Other Highlights
+
+`.Site.GetPage` can now also be used to get regular pages ([#2844](https://github.com/spf13/hugo/issues/2844)):
+
+```go
+{{ (.Site.GetPage "page" "blog" "mypost.md" ).Title }}
+```
+
+Also, considerable work has been put into writing automated benchmark tests for the site builds, and we&#39;re happy to report that although this release comes with fundamental structural changes, this version is -- in general -- even faster than the previous. It’s quite a challenge to consistently add significant new functionality and simultaneously maintain the stellar performance Hugo is famous for. 
+
+
+ 
+## Notes
+
+`.Site.Sections` is replaced. We have reworked how sections work in Hugo, they can now be nested and are no longer taxonomies. If you use the old collection, you should get detailed upgrade instructions in the log when you run `hugo`. For more information, see this [demo site](http://hugotest.bep.is/). 
+
+## Enhancements
+
+### Templates
+
+* Add `uint` support to `In` [b82cd82f](https://github.com/spf13/hugo/commit/b82cd82f1198a371ed94bda7faafe22813f4cb29) [@moorereason](https://github.com/moorereason) 
+* Support interfaces in `union` [204c3a9e](https://github.com/spf13/hugo/commit/204c3a9e32fcf6617ede978e35d3e2e89a5b491c) [@moorereason](https://github.com/moorereason) [#3411](https://github.com/spf13/hugo/issues/3411) 
+* Add `uniq` function [e28d9aa4](https://github.com/spf13/hugo/commit/e28d9aa42c3429d22fe254e69e4605aaf1e684f3) [@adiabatic](https://github.com/adiabatic) 
+* Handle `template.HTML` and friends in `ToInt` [4113693a](https://github.com/spf13/hugo/commit/4113693ac1b275f3a40aa5c248269340ef9b57f6) [@moorereason](https://github.com/moorereason) [#3308](https://github.com/spf13/hugo/issues/3308) 
+
+
+### Core
+
+* Make the `RSS feed` use the date for the node it represents [f1da5a15](https://github.com/spf13/hugo/commit/f1da5a15a37666ee59350d6600a8c14c1383f5bc) [@bep](https://github.com/bep) [#2708](https://github.com/spf13/hugo/issues/2708) 
+* Enable `nested sections` [b3968939](https://github.com/spf13/hugo/commit/b39689393ccb8434d9a57658a64b77568c718e99) [@bep](https://github.com/bep) [#465](https://github.com/spf13/hugo/issues/465) 
+* Add test for &#34;no 404&#34; in `sitemap` [8aaec644](https://github.com/spf13/hugo/commit/8aaec644a90d09bd7f079d35d382f76bb4ed35db) [@bep](https://github.com/bep) [#3563](https://github.com/spf13/hugo/issues/3563) 
+* Support regular pages in `.Site.GetPage` [e0c2e798](https://github.com/spf13/hugo/commit/e0c2e798201f75ae6e9a81a7442355288c2d141b) [@bep](https://github.com/bep) [#2844](https://github.com/spf13/hugo/issues/2844) 
+[#3082](https://github.com/spf13/hugo/issues/3082) 
+
+### Performance
+* Add site building benchmarks [8930e259](https://github.com/spf13/hugo/commit/8930e259d78cba4041b550cc51a7f40bc91d7c20) [@bep](https://github.com/bep) [#3535](https://github.com/spf13/hugo/issues/3535) 
+* Add a cache to `GetPage` which makes it much faster [50d11138](https://github.com/spf13/hugo/commit/50d11138f3e18b545c15fadf52f7b0b744bf3e7c) [@bep](https://github.com/bep) 
+* Speed up `GetPage` [fbb78b89](https://github.com/spf13/hugo/commit/fbb78b89df8ccef8f0ab26af00aa45d35c1ee2cf) [@bep](https://github.com/bep) [#3503](https://github.com/spf13/hugo/issues/3503) 
+* Add BenchmarkFrontmatterTags [3d9c4f51](https://github.com/spf13/hugo/commit/3d9c4f513b0443648d7e88995e351df1739646d2) [@bep](https://github.com/bep) [#3464](https://github.com/spf13/hugo/issues/3464) 
+* Add `benchSite.sh` to make it easy to run Hugo performance benchmarks [d74452cf](https://github.com/spf13/hugo/commit/d74452cfe8f69a85ec83e05481e16bebf199a5cb) [@bep](https://github.com/bep) 
+* Cache language config [4aff2b6e](https://github.com/spf13/hugo/commit/4aff2b6e7409a308f30cff1825fec02991e0d56a) [@bep](https://github.com/bep) 
+* Temporarily revert to BurntSushi for `TOML` front matter handling; it is currently much faster [0907a5c1](https://github.com/spf13/hugo/commit/0907a5c1c293755e6bf297246f07888448d81f8b) [@bep](https://github.com/bep) [#3541](https://github.com/spf13/hugo/issues/3541) [#3464](https://github.com/spf13/hugo/issues/3464) 
+* Add a simple partitioned lazy cache [87203139](https://github.com/spf13/hugo/commit/87203139c38e0b992c96d7b8a23c7730649c68e5) [@bep](https://github.com/bep) 
+
+### Other
+
+* Add `noindex` tag to HTML generated by Hugo aliases [d5ab7f08](https://github.com/spf13/hugo/commit/d5ab7f087d967b30e7de7d789e6ad3091b42f1f7) [@onedrawingperday](https://github.com/onedrawingperday) 
+* Update Go versions [bde807bd](https://github.com/spf13/hugo/commit/bde807bd1e560fb4cc765c0fc22132db7f8a0801) [@bep](https://github.com/bep) 
+* Remove the `rlimit` tweaking on `macOS` [bcd32f10](https://github.com/spf13/hugo/commit/bcd32f1086c8c604fb22a7496924e41cc46b1605) [@bep](https://github.com/bep) [#3512](https://github.com/spf13/hugo/issues/3512) 
+
+### Docs
+* Rewrite “Archetypes” article [@davidturnbull](https://github.com/davidturnbull) [#3543](https://github.com/spf13/hugo/pull/3543/) 
+* Remove Unmaintaned Frontends from Tools. [f41f7282](https://github.com/spf13/hugo/commit/f41f72822251c9a31031fd5b3dda585c57c8b028) [@onedrawingperday](https://github.com/onedrawingperday) 
+
+## Fixes
+
+### Core
+* Improve `live-reload` on directory structure changes making removal of directories or pasting new content directories into  `/content` just work [fe901b81](https://github.com/spf13/hugo/commit/fe901b81191860b60e6fcb29f8ebf87baef2ee79) [@bep](https://github.com/bep) [#3570](https://github.com/spf13/hugo/issues/3570) 
+* Respect `disableKinds=[&#34;sitemap&#34;]` [69d92dc4](https://github.com/spf13/hugo/commit/69d92dc49cb8ab9276ab013d427ba2d9aaf9135d) [@bep](https://github.com/bep) [#3544](https://github.com/spf13/hugo/issues/3544) 
+* Fix `disablePathToLower` regression [5be04486](https://github.com/spf13/hugo/commit/5be0448635fdf5fe6b1ee673e869f2b9baf1a5c6) [@bep](https://github.com/bep) [#3374](https://github.com/spf13/hugo/issues/3374) 
+* Fix `ref`/`relref` issue with duplicate base filenames [612f6e3a](https://github.com/spf13/hugo/commit/612f6e3afe0510c31f70f3621f3dc8ba609dade4) [@bep](https://github.com/bep) [#2507](https://github.com/spf13/hugo/issues/2507) 
+
+### Docs
+
+* Fix parameter name in `YouTube` shortcode section [37e37877](https://github.com/spf13/hugo/commit/37e378773fbc127863f2b7a389d5ce3a14674c73) [@zivbk1](https://github.com/zivbk1) 

--- a/content/news/0-23.md
+++ b/content/news/0-23.md
@@ -1,0 +1,45 @@
+---
+date: 2017-06-16T17:53:58-04:00
+categories: ["Releases"]
+description: "Hugo 0.23 is mainly a release that handles all the small changes needed to get Hugo moved to a GitHub organisation"
+link: ""
+title: "June Release"
+draft: false
+author: bep
+---
+
+Hugo `0.23` is mainly a release that handles all the small changes needed to get Hugo moved to a GitHub organisation: [gohugoio](https://github.com/gohugoio), but it also contains a couple of important fixes that makes this an update worth-while for all.
+
+Hugo now has:
+
+* 17739&#43; [stars](https://github.com/gohugoio/hugo/stargazers)
+* 494&#43; [contributors](https://github.com/gohugoio/hugo/graphs/contributors)
+* 165&#43; [themes](http://themes.gohugo.io/)
+
+## Fixes
+
+* Fix handling of duplicate footnotes [a9e551a1](https://github.com/gohugoio/hugo/commit/a9e551a100e60a603210ee083103dd73369d6a98) [@bep](https://github.com/bep) [#1912](https://github.com/gohugoio/hugo/issues/1912) 
+*  Add support for spaces in project folder for `GitInfo` #3533 #3552
+
+## GitHub organisation related changes
+
+* Update layout references to gohugoio/hugo [66d4850b](https://github.com/gohugoio/hugo/commit/66d4850b89db293dc58e828de784037f06c6c8dc) [@bep](https://github.com/bep) 
+* Update content references to gohugoio/hugo [715ff1f8](https://github.com/gohugoio/hugo/commit/715ff1f87406edf27738c8c0f52fe185fa974ee8) [@bep](https://github.com/bep) 
+* Add note on updates for rpm-based distros [52a0cea6](https://github.com/gohugoio/hugo/commit/52a0cea65de7b75ae1662abe3dec36fca3604617) [@daftaupe](https://github.com/daftaupe) 
+* Update logo link in README [ccb8300d](https://github.com/gohugoio/hugo/commit/ccb8300d380636d75a39f4133284eb0109e836c3) [@bep](https://github.com/bep) 
+* Remove docs building from CI builds [214dbdfb](https://github.com/gohugoio/hugo/commit/214dbdfb6f016d21415bc1ed511a37a084238878) [@bep](https://github.com/bep) 
+* Adjust docs path [729be807](https://github.com/gohugoio/hugo/commit/729be8074bddb58c9111f32c55cc769e49cd0d5a) [@bep](https://github.com/bep) 
+* Add docs as submodule [6cee0dfe](https://github.com/gohugoio/hugo/commit/6cee0dfe53899d433afc3c173a87d56265904cb0) [@bep](https://github.com/bep) 
+* Update Gitter link in README [fbb25014](https://github.com/gohugoio/hugo/commit/fbb25014e1306ce7127d53e5fc4fc49867790336) [@bep](https://github.com/bep) 
+* Change Windows build badge link, take #3 [86543d6a](https://github.com/gohugoio/hugo/commit/86543d6a50251b40540ebd0b851d45eb99d017c7) [@bep](https://github.com/bep) 
+* Update Windows build link [e6ae32a0](https://github.com/gohugoio/hugo/commit/e6ae32a0ba75b9894418227e87391defbb1b3b49) [@bep](https://github.com/bep) 
+* Update links in CONTRIBUTING.md due to the org transition [95386544](https://github.com/gohugoio/hugo/commit/95386544e858949a2baa414f395f30aaf66a6257) [@digitalcraftsman](https://github.com/digitalcraftsman) 
+* Update source path in Dockerfile due to the org transition [7b99fb9f](https://github.com/gohugoio/hugo/commit/7b99fb9f1ca8381457afe9d8e953a388b8ada182) [@digitalcraftsman](https://github.com/digitalcraftsman) 
+* Update clone folder in appveyor.yml due to the org transition [d531d17b](https://github.com/gohugoio/hugo/commit/d531d17b3be0b14faf4934611e01ac3289e37835) [@digitalcraftsman](https://github.com/digitalcraftsman) 
+* Update import path in snapcraft.yaml due to the org transition [9266bf9d](https://github.com/gohugoio/hugo/commit/9266bf9d4c24592b875a7f6b92f761b4cea40879) [@digitalcraftsman](https://github.com/digitalcraftsman) 
+* Run gofmt to get imports in line vs gohugoio/hugo [873a6f18](https://github.com/gohugoio/hugo/commit/873a6f18851bcda79d562ff6c02e1109e8e31a88) [@bep](https://github.com/bep) 
+* Update Makefile vs gohugoio/hugo [f503d76a](https://github.com/gohugoio/hugo/commit/f503d76a3b2719bbb65ab9df5595d0dbc871fae9) [@bep](https://github.com/bep) 
+* Update README to point to gohugoio/hugo [93643860](https://github.com/gohugoio/hugo/commit/93643860c9db10c6c32176b17cc83f1c317279bd) [@bep](https://github.com/bep) 
+* Update examples to point to gohugoio/hugo [db46bcf8](https://github.com/gohugoio/hugo/commit/db46bcf82d060656d4bc731550e63ec9cf8576f2) [@bep](https://github.com/bep) 
+* Update textual references in Go source to point to gohugoio/hugo [c17ad675](https://github.com/gohugoio/hugo/commit/c17ad675e8fcdb2db40fc50816b8f016bc14294c) [@bep](https://github.com/bep) 
+* Update import paths to gohugoio/hugo [d8717cd4](https://github.com/gohugoio/hugo/commit/d8717cd4c74e80ea8e20adead9321412a2d76022) [@bep](https://github.com/bep) 

--- a/content/news/0-24-1.md
+++ b/content/news/0-24-1.md
@@ -1,0 +1,21 @@
+---
+date: 2017-06-24T17:53:58-04:00
+categories: ["Releases"]
+description: "This release fixes some important archetype-related regressions from Hugo 0.24"
+link: ""
+title: "June Release"
+draft: false
+author: bep
+---
+
+This release fixes some important **archetype-related regressions** from the recent Hugo 0.24-release.
+
+## Fixes
+
+* Fix archetype regression when no archetype file [4294dd8d](https://github.com/gohugoio/hugo/commit/4294dd8d9d22bd8107b7904d5389967da1f83f27) [@bep](https://github.com/bep) [#3626](https://github.com/gohugoio/hugo/issues/3626) 
+* Preserve shortcodes in archetype templates [b63e4ee1](https://github.com/gohugoio/hugo/commit/b63e4ee198c875b73a6a9af6bb809589785ed589) [@bep](https://github.com/bep) [#3623](https://github.com/gohugoio/hugo/issues/3623) 
+* Fix handling of timezones with positive UTC offset (e.g., +0800) in TOML [0744f81e](https://github.com/gohugoio/hugo/commit/0744f81ec00bb8888f59d6c8b5f57096e07e70b1) [@bep](https://github.com/bep) [#3628](https://github.com/gohugoio/hugo/issues/3628) 
+
+## Enhancements
+
+* Create default archetype on new site [bfa336d9](https://github.com/gohugoio/hugo/commit/bfa336d96173377b9bbe2298dbd101f6a718c174) [@bep](https://github.com/bep) [#3626](https://github.com/gohugoio/hugo/issues/3626) 

--- a/content/news/0-24.md
+++ b/content/news/0-24.md
@@ -1,0 +1,73 @@
+---
+date: 2017-06-17T17:53:58-04:00
+categories: ["Releases"]
+description: "The Revival of the Archetypes!"
+link: ""
+title: "June Release"
+draft: false
+author: bep
+---
+
+> "A feature that could be the name of the next Indiana Jones movie deserves its own release," says [@bep](https://github.com/bep).
+
+Hugo now handles the **archetype files as Go templates**. This means that the issues with sorting and lost comments are long gone. This also means that you will have to supply all values, including title and date. But this also opens up a lot of new windows.
+
+A fictional example for the section `newsletter` and the archetype file `archetypes/newsletter.md`:
+
+```markdown
+---
+title: "{{ replace .TranslationBaseName "-" " " | title }}"
+date: {{ .Date }}
+draft: true
+---
+
+**Insert Lead paragraph here.**
+
+<!--more-->
+
+## New Cool Posts
+
+{{ range first 10 ( where .Site.RegularPages "Type" "cool" ) }}
+* {{ .Title }}
+{{ end }}
+```
+
+And then create a new post with:
+
+```bash
+hugo new newsletter/the-latest-cool.stuff.md
+```
+
+**Note:** the site will only be built if the `.Site` is in use in the archetype file, and this can be time consuming for big sites.
+
+**Hot Tip:** If you set the `newContentEditor` configuration variable to an editor on your `PATH`, the newly created article will be opened.
+
+The above _newsletter type archetype_ illustrates the possibilities: The full Hugo `.Site` and all of Hugo&#39;s template funcs can be used in the archetype file.
+
+**Also, Hugo now supports archetype files for all content formats, not just markdown.**
+
+Hugo now has:
+
+* 17839&#43; [stars](https://github.com/gohugoio/hugo/stargazers)
+* 493&#43; [contributors](https://github.com/gohugoio/hugo/graphs/contributors)
+* 166&#43; [themes](http://themes.gohugo.io/)
+
+## Notes
+
+* Archetype files now need to be complete, including `title` and `date`.
+* The `-f` (format) flag in `hugo new` is removed: Now use the archetype files as is.
+
+## Enhancements
+
+* Support extension-less media types. The motivation behind this change is to support Netlify&#39;s `_redirects` files, so we can generate server-side redirects for the Hugo docs site. See [this commit](https://github.com/gohugoio/hugoDocs/commit/c1ab9894e8292e0a74c43bbca2263b1fb3840f9e) to see how we configured that. [0f40e1fa](https://github.com/gohugoio/hugo/commit/0f40e1fadfca2276f65adefa6d7d5d63aef9160a) [@bep](https://github.com/bep) [#3614](https://github.com/gohugoio/hugo/issues/3614) 
+* Add `disableAliases` [516e6c6d](https://github.com/gohugoio/hugo/commit/516e6c6dc5733cdaf985317d58eedbc6ec0ef2f7) [@bep](https://github.com/bep) [#3613](https://github.com/gohugoio/hugo/issues/3613) 
+* Support non-md files as archetype files [19f2e729](https://github.com/gohugoio/hugo/commit/19f2e729135af700c5d4aa06e7b3540e6d4847fd) [@bep](https://github.com/bep) [#3597](https://github.com/gohugoio/hugo/issues/3597) [#3618](https://github.com/gohugoio/hugo/issues/3618) 
+* Identify extension-less text types as text [c43b512b](https://github.com/gohugoio/hugo/commit/c43b512b4700f76ac77f12d632bb030c3a241393) [@bep](https://github.com/bep) [#3614](https://github.com/gohugoio/hugo/issues/3614) 
+* Add `.Site` to the archetype templates [662e12f3](https://github.com/gohugoio/hugo/commit/662e12f348a638a6fcc92a416ee7f7c2a7ef8792) [@bep](https://github.com/bep) [#1629](https://github.com/gohugoio/hugo/issues/1629) 
+* Use archetype template as-is as a Go template [422057f6](https://github.com/gohugoio/hugo/commit/422057f60709696bbbd1c38c9ead2bf114d47e31) [@bep](https://github.com/bep) [#452](https://github.com/gohugoio/hugo/issues/452) [#1629](https://github.com/gohugoio/hugo/issues/1629) 
+* Update links to new discuss URL [4aa12390](https://github.com/gohugoio/hugo/commit/4aa1239070bb9d4324d3582f3e809b702a59d3ac) [@bep](https://github.com/bep) 
+
+## Fixes
+
+* Fix error handling for `JSON` front matter [fb53987a](https://github.com/gohugoio/hugo/commit/fb53987a4ff2acb9da8dec6ec7b11924d37352ce) [@bep](https://github.com/bep) [#3610](https://github.com/gohugoio/hugo/issues/3610) 
+* Fix handling of quoted brackets in `JSON` front matter [3183b9a2](https://github.com/gohugoio/hugo/commit/3183b9a29d8adac962fbc73f79b04542f4c4c55d) [@bep](https://github.com/bep) [#3511](https://github.com/gohugoio/hugo/issues/3511) 

--- a/content/news/0-25-1.md
+++ b/content/news/0-25-1.md
@@ -1,0 +1,24 @@
+---
+date: 2017-07-10T17:53:58-04:00
+categories: ["Releases"]
+description: "This is a bug-fix release with a couple of important fixes"
+link: ""
+title: "July Release"
+draft: false
+author: bep
+---
+
+This is a bug-fix release with a couple of important fixes.
+
+Hugo now has:
+
+* 18277+ [stars](https://github.com/gohugoio/hugo/stargazers)
+* 456+ [contributors](https://github.com/gohugoio/hugo/graphs/contributors)
+* 170+ [themes](http://themes.gohugo.io/)
+
+## Fixes
+
+* Fix union when the first slice is empty [dbbc5c48](https://github.com/gohugoio/hugo/commit/dbbc5c4810a04ac06fad7500d88cf5c3bfe0c7fd) [@bep](https://github.com/bep) [#3686](https://github.com/gohugoio/hugo/issues/3686)
+* Navigate to changed on CREATE When working with content from IntelliJ IDE, like WebStorm, every file save is followed by two events: "RENAME" and then "CREATE". [7bcc1ce6](https://github.com/gohugoio/hugo/commit/7bcc1ce659710f2220b400ce3b76e50d2e48b241) [@miltador](https://github.com/miltador) 
+* Final (!) fix for issue with escaped JSON front matter [7f82b41a](https://github.com/gohugoio/hugo/commit/7f82b41a24af0fd04d28fbfebf9254766a3c6e6f) [@bep](https://github.com/bep) [#3682](https://github.com/gohugoio/hugo/issues/3682)
+* Fix issue with escaped JSON front matter [84db6c74](https://github.com/gohugoio/hugo/commit/84db6c74a084d2b52117b999d4ec343cd3389a68) [@bep](https://github.com/bep) [#3682](https://github.com/gohugoio/hugo/issues/3682)

--- a/content/news/0-25.md
+++ b/content/news/0-25.md
@@ -1,0 +1,77 @@
+---
+date: 2017-07-07T17:53:58-04:00
+categories: ["Releases"]
+description: "Hugo 0.25 automatically opens the page you&#39;re working on in the browser"
+link: ""
+title: "July Release"
+draft: false
+author: bep
+---
+
+Hugo `0.25` is the **Kinder Surprise**: It automatically opens the page you&#39;re working on in the browser, it adds full `AND` and `OR` support in page queries, and you can now have templates per language.
+
+![Hugo Open on Save](https://cdn-standard5.discourse.org/uploads/gohugo/optimized/2X/6/622088d4a8eacaf62bbbaa27dab19d789e10fe09_1_690x345.gif "Hugo Open on Save")
+
+If you start with `hugo server --navigateToChanged`, Hugo will navigate to the relevant page on save (see animated GIF). This is extremely useful for site-wide edits. Another very useful feature in this version is the added support for `AND` (`intersect`)  and `OR` (`union`)  filters when combined with `where`.
+
+Example:
+
+```go
+{{ $pages := where .Site.RegularPages "Type" "not in" (slice "page" "about") }}
+{{ $pages := $pages | union (where .Site.RegularPages "Params.pinned" true) }}
+{{ $pages := $pages | intersect (where .Site.RegularPages "Params.images" "!=" nil) }}
+```
+
+The above fetches regular pages not of `page` or `about` type unless they are pinned. And finally, we exclude all pages with no `images` set in Page params.
+
+This release represents **36 contributions by 12 contributors** to the main Hugo code base. [@bep](https://github.com/bep) still leads the Hugo development with his witty Norwegian humor, and once again contributed a significant amount of additions. But also a big shoutout to [@yihui](https://github.com/yihui), [@anthonyfok](https://github.com/anthonyfok), and [@kropp](https://github.com/kropp) for their ongoing contributions. And as always a big thanks to [@digitalcraftsman](https://github.com/digitalcraftsman) for his relentless work on keeping the documentation and the themes site in pristine condition.
+
+Hugo now has:
+
+* 18209&#43; [stars](https://github.com/gohugoio/hugo/stargazers)
+* 455&#43; [contributors](https://github.com/gohugoio/hugo/graphs/contributors)
+* 168&#43; [themes](http://themes.gohugo.io/)
+
+## Enhancements
+
+### Templates
+
+* Add `Pages` support to `intersect` (`AND`) and `union`(`ÒR`). This makes the `where` template func even more powerful. [ccdd08d5](https://github.com/gohugoio/hugo/commit/ccdd08d57ab64441e93d6861ae126b5faacdb92f) [@bep](https://github.com/bep) [#3174](https://github.com/gohugoio/hugo/issues/3174)
+* Add `math.Log` function. This is very handy for creating tag clouds. [34c56677](https://github.com/gohugoio/hugo/commit/34c566773a1364077e1397daece85b22948dc721) [@artem-sidorenko](https://github.com/artem-sidorenko) 
+* Add `WebP` images support [8431c8d3](https://github.com/gohugoio/hugo/commit/8431c8d39d878c18c6b5463d9091a953608df10b) [@bep](https://github.com/bep) [#3529](https://github.com/gohugoio/hugo/issues/3529)
+* Only show post&#39;s own keywords in schema.org [da72805a](https://github.com/gohugoio/hugo/commit/da72805a4304a57362e8e79a01cc145767b027c5) [@brunoamaral](https://github.com/brunoamaral) [#2635](https://github.com/gohugoio/hugo/issues/2635)[#2646](https://github.com/gohugoio/hugo/issues/2646)
+* Simplify the `Disqus` template a little bit (#3655) [eccb0647](https://github.com/gohugoio/hugo/commit/eccb0647821e9db20ba9800da1b4861807cc5205) [@yihui](https://github.com/yihui) 
+* Improve the built-in Disqus template (#3639) [2e1e4934](https://github.com/gohugoio/hugo/commit/2e1e4934b60ce8081a7f3a79191ed204f3098481) [@yihui](https://github.com/yihui) 
+
+### Output
+
+* Support templates per site/language. This is for both regular templates and shortcode templates. [aa6b1b9b](https://github.com/gohugoio/hugo/commit/aa6b1b9be7c9d7322333893b642aaf8c7a5f2c2e) [@bep](https://github.com/bep) [#3360](https://github.com/gohugoio/hugo/issues/3360)
+
+### Core
+
+* Extend the sections API [a1d260b4](https://github.com/gohugoio/hugo/commit/a1d260b41a6673adef679ec4e262c5f390432cf5) [@bep](https://github.com/bep) [#3591](https://github.com/gohugoio/hugo/issues/3591)
+* Make `.Site.Sections` return the top level sections [dd9b1baa](https://github.com/gohugoio/hugo/commit/dd9b1baab0cb860a3eb32fd9043bac18cab3f9f0) [@bep](https://github.com/bep) [#3591](https://github.com/gohugoio/hugo/issues/3591)
+* Render `404.html` for all languages [41805dca](https://github.com/gohugoio/hugo/commit/41805dca9e40e9b0952e04d06074e6fc91140495) [@mitchchn](https://github.com/mitchchn) [#3598](https://github.com/gohugoio/hugo/issues/3598)
+
+### Other
+
+* Support human-readable `YAML` boolean values in `undraft` [1039356e](https://github.com/gohugoio/hugo/commit/1039356edf747f044c989a5bc0e85d792341ed5d) [@kropp](https://github.com/kropp) 
+* `hugo import jekyll` support nested `_posts` directories [7ee1f25e](https://github.com/gohugoio/hugo/commit/7ee1f25e9ef3be8f99c171e8e7982f4f82c13e16) [@coderzh](https://github.com/coderzh) [#1890](https://github.com/gohugoio/hugo/issues/1890)[#1911](https://github.com/gohugoio/hugo/issues/1911)
+* Update `Dockerfile` and add Docker optimizations [118f8f7c](https://github.com/gohugoio/hugo/commit/118f8f7cf22d756d8a894ff93551974a806f2155) [@ellerbrock](https://github.com/ellerbrock) 
+* Add Blackfriday `joinLines` extension support (#3574) [a5440496](https://github.com/gohugoio/hugo/commit/a54404968a4b36579797f2e7ff7f5eada94866d9) [@choueric](https://github.com/choueric) 
+* add `--initial-header-level=2` to rst2html (#3528) [bfce30d8](https://github.com/gohugoio/hugo/commit/bfce30d85972c27c27e8a2caac9db6315f813298) [@frankbraun](https://github.com/frankbraun) 
+* Support open "current content page" in browser [c825a731](https://github.com/gohugoio/hugo/commit/c825a7312131b4afa67ee90d593640dee3525d98) [@bep](https://github.com/bep) [#3643](https://github.com/gohugoio/hugo/issues/3643)
+* Make `--navigateToChanged` more robust on Windows [30e14cc3](https://github.com/gohugoio/hugo/commit/30e14cc31678ddc204b082ab362f86b6b8063881) [@anthonyfok](https://github.com/anthonyfok) [#3645](https://github.com/gohugoio/hugo/issues/3645)
+* Remove the docs submodule [31393f60](https://github.com/gohugoio/hugo/commit/31393f6024416ea1b2e61d1080dfd7104df36eda) [@bep](https://github.com/bep) [#3647](https://github.com/gohugoio/hugo/issues/3647)
+* Use `example.com` as homepage for new theme [aff1ac32](https://github.com/gohugoio/hugo/commit/aff1ac3235b6c075d01f7237addf44fecdd36d82) [@anthonyfok](https://github.com/anthonyfok) 
+
+## Fixes
+
+### Templates
+
+* Fix `in` function for JSON arrays [d12cf5a2](https://github.com/gohugoio/hugo/commit/d12cf5a25df00fa16c59f0b2ae282187a398214c) [@bep](https://github.com/bep) [#1468](https://github.com/gohugoio/hugo/issues/1468)
+
+### Other
+
+* Fix handling of `JSON` front matter with escaped quotes [e10e51a0](https://github.com/gohugoio/hugo/commit/e10e51a00827b9fdc1bee51439fef05afc529831) [@bep](https://github.com/bep) [#3661](https://github.com/gohugoio/hugo/issues/3661)
+* Fix typo in code comment [56d82aa0](https://github.com/gohugoio/hugo/commit/56d82aa025f4d2edb1dc6315132cd7ab52df649a) [@dvic](https://github.com/dvic) 


### PR DESCRIPTION
I tried my best insert the right meta data in the front matter.

There are some issues related to this pull requests:

- the already existing release notes were titled after the schema "<month> release" where month is the month of the release. However, with the lately improvements of the release process we released multiple times a month. Hence I suggest to use the version number instead, e.g. "Hugo <version> has been released"
- the title in the left sidebar (defined by `title` in the front matter) is sometimes a bit long and should be improved. On smaller bugfix releases I omitted the title due to the lack of content.
- The summaries of the release notes at http://localhost:1313/categories/releases/ contains Markdown that isn't rendered as such. Either we use the `markdownify` template func, which could mess up the layout due to headings, or we have to think about the insertion of a custom summary divider. The same applies to the "news section" on the homepage below the hero.